### PR TITLE
Free memory from pool (avoid pointer damage)

### DIFF
--- a/src/ngx_inet_slab.c
+++ b/src/ngx_inet_slab.c
@@ -462,11 +462,11 @@ ngx_inet_resolve_host_slab(ngx_slab_pool_t *pool, ngx_url_t *u)
 
     if (getaddrinfo((char *) host, NULL, &hints, &res) != 0) {
         u->err = "host not found";
-        ngx_free(host);
+        ngx_slab_free_locked(pool, host);
         return NGX_ERROR;
     }
 
-    ngx_free(host);
+    ngx_slab_free_locked(pool, host);
 
     for (i = 0, rp = res; rp != NULL; rp = rp->ai_next) {
 
@@ -606,7 +606,7 @@ ngx_inet_resolve_host_slab(ngx_slab_pool_t *pool, ngx_url_t *u)
 
         h = gethostbyname((char *) host);
 
-        ngx_free(host);
+        ngx_slab_free_locked(pool, host);
 
         if (h == NULL || h->h_addr_list[0] == NULL) {
             u->err = "host not found";


### PR DESCRIPTION
1) note, ngx_free on memory from pool can result in either pool being still marked as used, or crashes when using shm in upstream.

2) there's an issue with memory staying dirty after ngx_parse_url_slab, so ngx_dynamic_upstream_op.c should (no idea, honestly..) care of it like this:

```
    if (u.url.data != NULL) {
        ngx_slab_free_locked(shpool, u.url.data);
    }
    if (u.addrs != NULL) {

        unsigned int i = 0;
        for (i = 0; i < u.naddrs; i++) {
            if (u.addrs[i].name.data != NULL) {
                ngx_slab_free_locked(shpool, u.addrs[i].name.data);
            }
            if (u.addrs[i].sockaddr != NULL) {
             ngx_slab_free_locked(shpool, u.addrs[i].sockaddr);
            }
        }

        ngx_slab_free_locked(shpool, u.addrs);
    }
```
