### PR TITLE
fix README API example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ $
 ## add
 
 ```bash
-$ curl "http://127.0.0.1:6000/dynamic?upstream=zone_for_backends&add=&server=127.0.0.1:6004"
+$ curl "http://127.0.0.1:6000/dynamic?upstream=zone_for_backends&server=127.0.0.1:6004&add="
 server 127.0.0.1:6001;
 server 127.0.0.1:6002;
 server 127.0.0.1:6003;
@@ -124,7 +124,7 @@ $
 ## remove
 
 ```bash
-$ curl "http://127.0.0.1:6000/dynamic?upstream=zone_for_backends&remove=&server=127.0.0.1:6003"
+$ curl "http://127.0.0.1:6000/dynamic?upstream=zone_for_backends&server=127.0.0.1:6003&remove="
 server 127.0.0.1:6001;
 server 127.0.0.1:6002;
 server 127.0.0.1:6004;


### PR DESCRIPTION
I noticed that your example written in README.md went wrong (in my environment), because query param order of "add" and "remove" APIs are incorrect😭🕰👻

 my env:
 - macOS HighSierra
 - nginx version: nginx/1.15.7 built by clang 10.0.0 (clang-1000.11.45.5)
 - ngx_dynamic_upstream : latest (commit https://github.com/cubicdaiya/ngx_dynamic_upstream/commit/cc5dac336d48ce184004c9dd93fce39af896587f)

correction:
❌ `curl "http://127.0.0.1:6000/dynamic?upstream=zone_for_backends&add=&server=127.0.0.1:6004"`
✔️ `curl "http://127.0.0.1:6000/dynamic?upstream=zone_for_backends&server=127.0.0.1:6004&add="`

It's because query params store not in a map but in an array, I think.
https://github.com/cubicdaiya/ngx_dynamic_upstream/blob/cc5dac336d48ce184004c9dd93fce39af896587f/src/ngx_dynamic_upstream_op.c#L70

Please check it and merge if necessary.